### PR TITLE
* Free bootstrap version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     ],
     "require": {
         "yiisoft/yii2": "~2.0.0",
-        "yiisoft/yii2-bootstrap": "~2.0.0",
+        "yiisoft/yii2-bootstrap": "~2.0",
         "bower-asset/selectize": "~0.12.0"
     },
     "require-dev": {


### PR DESCRIPTION
Allows use with the 2.1 branch of yii2-bootstrap, which uses bootstrap 4.
Seems to work fine with selectize.bootstrap3.css.
